### PR TITLE
Handle empty ViewPager

### DIFF
--- a/vpbs/src/main/java/biz/laenger/android/vpbs/ViewPagerBottomSheetBehavior.java
+++ b/vpbs/src/main/java/biz/laenger/android/vpbs/ViewPagerBottomSheetBehavior.java
@@ -612,6 +612,10 @@ public class ViewPagerBottomSheetBehavior<V extends View> extends CoordinatorLay
         if (view instanceof ViewPager) {
             ViewPager viewPager = (ViewPager) view;
             View currentViewPagerChild = ViewPagerUtils.getCurrentView(viewPager);
+            if(currentViewPagerChild == null){
+                return null;
+            }
+
             View scrollingChild = findScrollingChild(currentViewPagerChild);
             if (scrollingChild != null) {
                 return scrollingChild;

--- a/vpbs/src/main/java/biz/laenger/android/vpbs/ViewPagerBottomSheetBehavior.java
+++ b/vpbs/src/main/java/biz/laenger/android/vpbs/ViewPagerBottomSheetBehavior.java
@@ -612,7 +612,7 @@ public class ViewPagerBottomSheetBehavior<V extends View> extends CoordinatorLay
         if (view instanceof ViewPager) {
             ViewPager viewPager = (ViewPager) view;
             View currentViewPagerChild = ViewPagerUtils.getCurrentView(viewPager);
-            if(currentViewPagerChild == null){
+            if (currentViewPagerChild == null) {
                 return null;
             }
 


### PR DESCRIPTION
I am using a ViewPager with an adapter. When the adapter was empty, the ViewPagerBottomSheetBehavior caused a NullPointerException. 